### PR TITLE
Update grunticon-lib to use @amp-namespaced version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampersandhq/gulpicon",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampersandhq/gulpicon",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "A gulp task wrapper for grunticon-lib.",
   "license": "MIT",
   "repository": "filamentgroup/gulpicon",

--- a/tasks/gulpicon.js
+++ b/tasks/gulpicon.js
@@ -1,6 +1,6 @@
 /*global require:true*/
 var log = require('fancy-log');
-var Grunticon = require('grunticon-lib');
+var Grunticon = require('@ampersandhq/grunticon-lib');
 
 module.exports = function(files, config) {
   'use strict';


### PR DESCRIPTION
I forgot to update the `require`d version to use the namespaced version; this resolves that issue, and the task works as expected. 